### PR TITLE
Added Missing Values for OrderType and QueryOrderInfo

### DIFF
--- a/kraken_rest_client/src/api/add_order.rs
+++ b/kraken_rest_client/src/api/add_order.rs
@@ -50,6 +50,13 @@ impl AddOrderRequest {
         }
     }
 
+    pub fn price2(self, price: &str) -> Self {
+        Self {
+            price2: Some(price.into()),
+            ..self
+        }
+    }
+
     // TODO: add typed flags builder.
 
     /// oflags = comma delimited list of order flags:

--- a/kraken_rest_client/src/api/query_orders_info.rs
+++ b/kraken_rest_client/src/api/query_orders_info.rs
@@ -71,6 +71,7 @@ pub struct OrderInfo {
     pub cost: String,
     pub fee: String,
     pub misc: String,
+    pub price: String,
     pub limitprice: String,
     pub refid: Option<String>,
     pub reason: Option<String>,

--- a/kraken_rest_client/src/types/order.rs
+++ b/kraken_rest_client/src/types/order.rs
@@ -27,6 +27,9 @@ pub enum OrderType {
     StopLossLimit,
     TakeProfitLimit,
     SettlePosition,
+    TrailingStop,
+    TrailingStopLimit
+
 }
 
 impl fmt::Display for OrderType {
@@ -39,6 +42,8 @@ impl fmt::Display for OrderType {
             Self::StopLossLimit => "stop-loss-limit",
             Self::TakeProfitLimit => "take-profit-limit",
             Self::SettlePosition => "settle-position",
+            Self::TrailingStop => "trailing-stop",
+            Self::TrailingStopLimit => "trailing-stop-limit"
         };
 
         write!(f, "{}", order_type)


### PR DESCRIPTION
Added based on documentation from the following:

AddOrderInfo: https://docs.kraken.com/api/docs/rest-api/add-order
QueryOrderInfo: https://docs.kraken.com/api/docs/rest-api/get-orders-info