### PR TITLE
Add iceberg to rest

### DIFF
--- a/kraken_rest_client/src/api/add_order.rs
+++ b/kraken_rest_client/src/api/add_order.rs
@@ -1,5 +1,5 @@
 use crate::{
-    types::{OrderDescription, OrderSide, OrderType},
+    types::{OrderSide, OrderType},
     Client, Result,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -255,6 +255,14 @@ impl AddOrderRequest {
     pub async fn send(self) -> Result<AddOrderResponse> {
         self.execute().await
     }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OrderDescription {
+    /// Order description
+    pub order: String,
+    /// Conditional close order description (if conditional close set)
+    pub close: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/kraken_rest_client/src/api/add_order.rs
+++ b/kraken_rest_client/src/api/add_order.rs
@@ -18,6 +18,8 @@ pub struct AddOrderRequest {
     price2: Option<String>,
     /// Order volume in lots.
     volume: String,
+    /// When placing an iceberg order, the amount to display for the order book no less than 1/15 the order total
+    displayvol: Option<String>,
     // Amount of leverage desired.
     leverage: Option<String>,
     /// Comma delimited list of order flags:
@@ -53,6 +55,13 @@ impl AddOrderRequest {
     pub fn price2(self, price: &str) -> Self {
         Self {
             price2: Some(price.into()),
+            ..self
+        }
+    }
+
+    pub fn displayvol(self, displayvol: &str) -> Self {
+        Self {
+            displayvol: Some(displayvol.into()),
             ..self
         }
     }
@@ -194,6 +203,10 @@ impl AddOrderRequest {
             query.push_str(&format!("&price2={}", price2));
         }
 
+        if let Some(displayvol) = &self.displayvol {
+            query.push_str(&format!("&displayvol={}", displayvol));
+        }
+
         if let Some(leverage) = &self.leverage {
             query.push_str(&format!("&leverage={}", leverage));
         }
@@ -266,6 +279,7 @@ impl Client {
             order_type,
             price: None,
             price2: None,
+            displayvol: None,
             volume: volume.to_string(),
             leverage: None,
             oflags: None,
@@ -293,6 +307,7 @@ impl Client {
             order_type: OrderType::Market,
             price: None,
             price2: None,
+            displayvol: None,
             volume: volume.to_string(),
             leverage: None,
             oflags: None,
@@ -321,6 +336,37 @@ impl Client {
             order_type: OrderType::Limit,
             price: Some(price.to_string()),
             price2: None,
+            displayvol: None,
+            volume: volume.to_string(),
+            leverage: None,
+            oflags: None,
+            timeinforce: None,
+            starttm: None,
+            expiretm: None,
+            userref: None,
+            validate: None,
+            close_order_type: None,
+            close_price: None,
+            close_price2: None,
+        }
+    }
+
+    pub fn add_iceberg_order(
+        &self,
+        pair: &str,
+        order_side: OrderSide,
+        displayvol: &str,
+        volume: &str,
+        price: &str,
+    ) -> AddOrderRequest {
+        AddOrderRequest {
+            client: self.clone(),
+            pair: pair.to_string(),
+            order_side,
+            order_type: OrderType::Limit,
+            price: Some(price.to_string()),
+            price2: None,
+            displayvol: Some(displayvol.to_string()),
             volume: volume.to_string(),
             leverage: None,
             oflags: None,

--- a/kraken_rest_client/src/api/add_order.rs
+++ b/kraken_rest_client/src/api/add_order.rs
@@ -1,5 +1,5 @@
 use crate::{
-    types::{OrderSide, OrderType},
+    types::{OrderDescription, OrderSide, OrderType},
     Client, Result,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -242,14 +242,6 @@ impl AddOrderRequest {
     pub async fn send(self) -> Result<AddOrderResponse> {
         self.execute().await
     }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct OrderDescription {
-    /// Order description
-    pub order: String,
-    /// Conditional close order description (if conditional close set)
-    pub close: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/kraken_rest_client/src/types/order.rs
+++ b/kraken_rest_client/src/types/order.rs
@@ -1,4 +1,5 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde::de::Error;
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Ord, PartialOrd, Hash)]
@@ -16,6 +17,23 @@ impl fmt::Display for OrderSide {
 
         write!(f, "{}", order_side)
     }
+}
+
+impl TryFrom<String> for OrderSide {
+    type Error = String;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        match s.to_lowercase().as_str() {
+            "sell" => Ok(OrderSide::Sell),
+            "buy" => Ok(OrderSide::Buy),
+            _ => Err(format!("Invalid order type: {}", s)),
+        }
+    }
+}
+
+fn orderside_from_str<'de, D>(deserializer: D) -> Result<OrderSide, D::Error> where D: Deserializer<'de>, {
+    let orderside = String::deserialize(deserializer)?;
+    OrderSide::try_from(orderside).map_err(D::Error::custom)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Ord, PartialOrd, Hash)]
@@ -52,6 +70,31 @@ impl fmt::Display for OrderType {
     }
 }
 
+impl TryFrom<String> for OrderType {
+    type Error = String;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        match s.to_lowercase().as_str() {
+            "market" => Ok(Self::Market),
+            "limit" => Ok(Self::Limit),
+            "iceberg" => Ok(Self::Iceberg),
+            "stop-loss" => Ok(Self::StopLoss),
+            "take-profit" => Ok(Self::TakeProfit),
+            "stop-loss-limit" => Ok(Self::StopLossLimit),
+            "take-profit-limit" => Ok(Self::TakeProfitLimit),
+            "settle-position" => Ok(Self::SettlePosition),
+            "trailing-stop" => Ok(Self::TrailingStop),
+            "trailing-stop-limit" => Ok(Self::TrailingStopLimit),
+            _ => Err(format!("Invalid order type: {}", s)),
+        }
+    }
+}
+
+fn ordertype_from_str<'de, D>(deserializer: D) -> Result<OrderType, D::Error> where D: Deserializer<'de>, {
+    let ordertype = String::deserialize(deserializer)?;
+    OrderType::try_from(ordertype).map_err(D::Error::custom)
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct OrderDescription {
     // pub ordertxid: Option<String>,
@@ -59,7 +102,9 @@ pub struct OrderDescription {
     pub pair: String,
     // pub time: f64,
     #[serde(rename = "type")]
+    #[serde(deserialize_with = "orderside_from_str")]
     pub orderside: OrderSide,
+    #[serde(deserialize_with = "ordertype_from_str")]
     pub ordertype: OrderType,
     pub price: String,
     pub price2: String,

--- a/kraken_rest_client/src/types/order.rs
+++ b/kraken_rest_client/src/types/order.rs
@@ -57,8 +57,8 @@ pub struct OrderDescription {
     pub pair: String,
     // pub time: f64,
     #[serde(rename = "type")]
-    pub orderside: String,
-    pub ordertype: String,
+    pub orderside: OrderSide,
+    pub ordertype: OrderType,
     pub price: String,
     pub price2: String,
     pub leverage: String,

--- a/kraken_rest_client/src/types/order.rs
+++ b/kraken_rest_client/src/types/order.rs
@@ -22,6 +22,7 @@ impl fmt::Display for OrderSide {
 pub enum OrderType {
     Market,
     Limit,
+    Iceberg,
     StopLoss,
     TakeProfit,
     StopLossLimit,
@@ -37,6 +38,7 @@ impl fmt::Display for OrderType {
         let order_type = match self {
             Self::Market => "market",
             Self::Limit => "limit",
+            Self::Iceberg => "iceberg",
             Self::StopLoss => "stop-loss",
             Self::TakeProfit => "take-profit",
             Self::StopLossLimit => "stop-loss-limit",


### PR DESCRIPTION
Minor cleanup to order types and duplicate structs while adding support for iceberg order types in the REST side.

Note: Does not presently validate the requirement that displayvol be >= 1/15 volume.